### PR TITLE
Use checkbox instead

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/widget/SearchLayout.kt
+++ b/app/src/main/java/com/hippo/ehviewer/widget/SearchLayout.kt
@@ -32,7 +32,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.hippo.easyrecyclerview.EasyRecyclerView
@@ -59,7 +58,7 @@ class SearchLayout @JvmOverloads constructor(
     private var mNormalView: View
     private var mNormalSearchMode: RadioGridGroup
     private var mNormalSearchModeHelp: ImageView
-    private var mEnableAdvanceSwitch: SwitchMaterial
+    private var mEnableAdvanceSwitch: CheckBox
     private var mAdvanceView: View
     private var mTableAdvanceSearch: AdvanceSearchTable
     private var mImageView: ImageSearchLayout
@@ -118,8 +117,6 @@ class SearchLayout @JvmOverloads constructor(
         mEnableAdvanceSwitch = mNormalView.findViewById(R.id.search_enable_advance)
         mNormalSearchModeHelp.setOnClickListener(this)
         mEnableAdvanceSwitch.setOnCheckedChangeListener(this)
-        mEnableAdvanceSwitch.switchPadding =
-            resources.getDimensionPixelSize(R.dimen.switch_padding)
         // Create advance view
         mAdvanceView = mInflater.inflate(R.layout.search_advance, null)
         mTableAdvanceSearch = mAdvanceView.findViewById(R.id.search_advance_search_table)

--- a/app/src/main/res/layout/search_normal.xml
+++ b/app/src/main/res/layout/search_normal.xml
@@ -89,7 +89,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1" />
 
-        <com.google.android.material.switchmaterial.SwitchMaterial
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/search_enable_advance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Why not use button ?

It's clear that button is too big after we switch to material3 button.

## Why not use radio button ?

1. ["Radio buttons convey that a set of items are options and can only be selected one at a time"](https://m3.material.io/components/switch/guidelines)
2. there are enough radio button in this card. I think place another component here will be better.
3. Yes, there are also enough checkbox in advanced_search card, but I have no choice. At least they are separated by a divider : (

## Why not use other solution ?

Yes, place an arrow here, and reverse direction on every click is better. But I'm poor, I didn't know how to implement it.